### PR TITLE
feat: add @defer directive for incremental delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.claude/

--- a/birdie_snapshots/complete_user_schema_structure.accepted
+++ b/birdie_snapshots/complete_user_schema_structure.accepted
@@ -1,5 +1,7 @@
 ---
 version: 1.5.5
 title: Complete User schema structure
+file: ./test/mochi_snapshot_test.gleam
+test_name: user_schema_structure_test
 ---
 Schema(Some(ObjectType("Query", None, dict.from_list([#("user", FieldDefinition("user", None, Named("User"), dict.from_list([#("id", ArgumentDefinition("id", Some("User ID"), NonNull(Named("ID")), None))]), None, False, None, None))]), [])), None, None, dict.from_list([#("User", ObjectTypeDef(ObjectType("User", Some("A user in the system"), dict.from_list([#("email", FieldDefinition("email", Some("User's email address"), NonNull(Named("String")), dict.from_list([]), None, False, None, None)), #("id", FieldDefinition("id", Some("Unique identifier"), NonNull(Named("ID")), dict.from_list([]), None, False, None, None)), #("name", FieldDefinition("name", Some("User's full name"), NonNull(Named("String")), dict.from_list([]), None, False, None, None))]), [])))]), dict.from_list([]), None)

--- a/src/mochi/batch.gleam
+++ b/src/mochi/batch.gleam
@@ -161,9 +161,13 @@ pub fn execute_with_operation_name(
       executor.execute(schema_def, new_doc, root_value, ctx, variables)
     }
     Error(msg) ->
-      executor.ExecutionResult(data: None, errors: [
-        executor.ValidationError(msg, [], location: None),
-      ], deferred: [])
+      executor.ExecutionResult(
+        data: None,
+        errors: [
+          executor.ValidationError(msg, [], location: None),
+        ],
+        deferred: [],
+      )
   }
 }
 
@@ -234,14 +238,18 @@ pub fn execute_batch(
     True ->
       BatchResult(
         results: [
-          executor.ExecutionResult(data: None, errors: [
-            executor.ValidationError(
-              "Batch size exceeds maximum of "
-                <> string.inspect(config.max_batch_size),
-              [],
-              location: None,
-            ),
-          ], deferred: []),
+          executor.ExecutionResult(
+            data: None,
+            errors: [
+              executor.ValidationError(
+                "Batch size exceeds maximum of "
+                  <> string.inspect(config.max_batch_size),
+                [],
+                location: None,
+              ),
+            ],
+            deferred: [],
+          ),
         ],
         all_succeeded: False,
         failure_count: 1,
@@ -274,13 +282,17 @@ fn execute_batch_internal(
           // If not continuing on error and we have a failure, skip remaining
           False, True -> #(
             [
-              executor.ExecutionResult(data: None, errors: [
-                executor.ValidationError(
-                  "Batch execution halted due to error",
-                  [],
-                  location: None,
-                ),
-              ], deferred: []),
+              executor.ExecutionResult(
+                data: None,
+                errors: [
+                  executor.ValidationError(
+                    "Batch execution halted due to error",
+                    [],
+                    location: None,
+                  ),
+                ],
+                deferred: [],
+              ),
               ..results_acc
             ],
             True,
@@ -326,13 +338,17 @@ fn execute_single_request(
         req.operation_name,
       )
     Error(parse_error) ->
-      executor.ExecutionResult(data: None, errors: [
-        executor.ValidationError(
-          "Parse error: " <> format_parse_error(parse_error),
-          [],
-          location: None,
-        ),
-      ], deferred: [])
+      executor.ExecutionResult(
+        data: None,
+        errors: [
+          executor.ValidationError(
+            "Parse error: " <> format_parse_error(parse_error),
+            [],
+            location: None,
+          ),
+        ],
+        deferred: [],
+      )
   }
 }
 

--- a/src/mochi/batch.gleam
+++ b/src/mochi/batch.gleam
@@ -163,7 +163,7 @@ pub fn execute_with_operation_name(
     Error(msg) ->
       executor.ExecutionResult(data: None, errors: [
         executor.ValidationError(msg, [], location: None),
-      ])
+      ], deferred: [])
   }
 }
 
@@ -241,7 +241,7 @@ pub fn execute_batch(
               [],
               location: None,
             ),
-          ]),
+          ], deferred: []),
         ],
         all_succeeded: False,
         failure_count: 1,
@@ -280,7 +280,7 @@ fn execute_batch_internal(
                   [],
                   location: None,
                 ),
-              ]),
+              ], deferred: []),
               ..results_acc
             ],
             True,
@@ -332,7 +332,7 @@ fn execute_single_request(
           [],
           location: None,
         ),
-      ])
+      ], deferred: [])
   }
 }
 

--- a/src/mochi/executor.gleam
+++ b/src/mochi/executor.gleam
@@ -245,10 +245,8 @@ fn execute_definition(
 ) -> ExecutionResult {
   case definition {
     ast.OperationDefinition(operation) -> execute_operation(context, operation)
-    // Fragment definitions are collected separately and applied during field execution.
-    // This branch is unreachable in practice since find_operation_by_name only
-    // returns OperationDefinition nodes.
-    ast.FragmentDefinition(_) -> ok_result(types.to_dynamic(dict.new()))
+    ast.FragmentDefinition(_) ->
+      panic as "unreachable: fragment definition reached execute_definition"
   }
 }
 
@@ -646,6 +644,26 @@ fn execute_selection_set(
   }
 }
 
+fn extract_defer_label(
+  directive: ast.Directive,
+  variables: Dict(String, Dynamic),
+) -> Option(String) {
+  directive.arguments
+  |> list.find(fn(a) { a.name == "label" })
+  |> result.try(fn(a) {
+    case a.value {
+      ast.StringValue(s) -> Ok(s)
+      ast.VariableValue(name) ->
+        dict.get(variables, name)
+        |> result.try(fn(v) {
+          decode.run(v, decode.string) |> result.map_error(fn(_) { Nil })
+        })
+      _ -> Error(Nil)
+    }
+  })
+  |> option.from_result
+}
+
 fn get_defer_info(
   selection: ast.Selection,
   variables: Dict(String, Dynamic),
@@ -658,23 +676,10 @@ fn get_defer_info(
   case list.find(directives, fn(d) { d.name == "defer" }) {
     Error(_) -> None
     Ok(directive) -> {
-      let if_value =
+      let should_defer =
         get_directive_bool_arg([directive], "defer", "if", variables)
-      let should_defer = option.unwrap(if_value, True)
-      let label =
-        directive.arguments
-        |> list.find(fn(a) { a.name == "label" })
-        |> result.try(fn(a) {
-          case a.value {
-            ast.StringValue(s) -> Ok(s)
-            ast.VariableValue(name) ->
-              dict.get(variables, name)
-              |> result.try(fn(v) { decode.run(v, decode.string) |> result.map_error(fn(_) { Nil }) })
-            _ -> Error(Nil)
-          }
-        })
-        |> option.from_result
-      Some(#(label, should_defer))
+        |> option.unwrap(True)
+      Some(#(extract_defer_label(directive, variables), should_defer))
     }
   }
 }

--- a/src/mochi/executor.gleam
+++ b/src/mochi/executor.gleam
@@ -1426,10 +1426,9 @@ fn aggregate_list_results(
   field_type: schema.FieldType,
   response_name: String,
 ) -> ExecutionResult {
-  // Single-pass: collect data, errors, and check for null errors simultaneously
-  let #(data_acc, errors_acc, has_null_error) =
-    list.fold(results, #([], [], False), fn(acc, result) {
-      let #(data_list, error_list, null_found) = acc
+  let #(data_acc, errors_acc, deferred_acc, has_null_error) =
+    list.fold(results, #([], [], [], False), fn(acc, result) {
+      let #(data_list, error_list, deferred_list, null_found) = acc
       let new_data = case result.data {
         Some(d) -> [d, ..data_list]
         None -> data_list
@@ -1442,21 +1441,32 @@ fn aggregate_list_results(
             _ -> False
           }
         })
-      #(new_data, [result.errors, ..error_list], new_null)
+      #(
+        new_data,
+        [result.errors, ..error_list],
+        [result.deferred, ..deferred_list],
+        new_null,
+      )
     })
 
   let errors = list.reverse(errors_acc) |> list.flatten
+  let deferred = list.reverse(deferred_acc) |> list.flatten
   let data_list = list.reverse(data_acc)
 
   case has_null_error, errors {
-    True, _ -> handle_list_null_error(field_type, response_name, errors)
+    True, _ ->
+      handle_list_null_error(field_type, response_name, errors, deferred)
     False, [] ->
-      ok_result(make_field(response_name, types.to_dynamic(data_list)))
+      ExecutionResult(
+        data: Some(make_field(response_name, types.to_dynamic(data_list))),
+        errors: [],
+        deferred: deferred,
+      )
     False, _ ->
       ExecutionResult(
         data: Some(make_field(response_name, types.to_dynamic(data_list))),
         errors: errors,
-        deferred: [],
+        deferred: deferred,
       )
   }
 }
@@ -1466,14 +1476,15 @@ fn handle_list_null_error(
   field_type: schema.FieldType,
   response_name: String,
   errors: List(ExecutionError),
+  deferred: List(DeferredPatch),
 ) -> ExecutionResult {
   case is_non_null_type(field_type) {
-    True -> ExecutionResult(data: None, errors: errors, deferred: [])
+    True -> ExecutionResult(data: None, errors: errors, deferred: deferred)
     False ->
       ExecutionResult(
         data: Some(make_field(response_name, types.to_dynamic(Nil))),
         errors: errors,
-        deferred: [],
+        deferred: deferred,
       )
   }
 }

--- a/src/mochi/executor.gleam
+++ b/src/mochi/executor.gleam
@@ -600,10 +600,7 @@ fn execute_selection_set(
                 label: label,
               )
             let new_deferred =
-              list.append(deferred_list, [
-                patch,
-                ..result.deferred
-              ])
+              list.append(deferred_list, [patch, ..result.deferred])
             #(data_map, errors_list, none_found, new_deferred)
           }
           _ -> {
@@ -662,12 +659,7 @@ fn get_defer_info(
     Error(_) -> None
     Ok(directive) -> {
       let if_value =
-        get_directive_bool_arg(
-          [directive],
-          "defer",
-          "if",
-          variables,
-        )
+        get_directive_bool_arg([directive], "defer", "if", variables)
       let should_defer = option.unwrap(if_value, True)
       let label =
         directive.arguments

--- a/src/mochi/executor.gleam
+++ b/src/mochi/executor.gleam
@@ -664,10 +664,13 @@ fn get_defer_info(
       let label =
         directive.arguments
         |> list.find(fn(a) { a.name == "label" })
-        |> result.map(fn(a) {
+        |> result.try(fn(a) {
           case a.value {
-            ast.StringValue(s) -> s
-            _ -> ""
+            ast.StringValue(s) -> Ok(s)
+            ast.VariableValue(name) ->
+              dict.get(variables, name)
+              |> result.try(fn(v) { decode.run(v, decode.string) |> result.map_error(fn(_) { Nil }) })
+            _ -> Error(Nil)
           }
         })
         |> option.from_result

--- a/src/mochi/executor.gleam
+++ b/src/mochi/executor.gleam
@@ -24,8 +24,21 @@ import mochi/validation
 // Types
 // ============================================================================
 
+pub type DeferredPatch {
+  DeferredPatch(
+    path: List(String),
+    data: Option(Dynamic),
+    errors: List(ExecutionError),
+    label: Option(String),
+  )
+}
+
 pub type ExecutionResult {
-  ExecutionResult(data: Option(Dynamic), errors: List(ExecutionError))
+  ExecutionResult(
+    data: Option(Dynamic),
+    errors: List(ExecutionError),
+    deferred: List(DeferredPatch),
+  )
 }
 
 pub type ExecutionError {
@@ -79,11 +92,11 @@ pub type FieldContext {
 // ============================================================================
 
 fn ok_result(data: Dynamic) -> ExecutionResult {
-  ExecutionResult(data: Some(data), errors: [])
+  ExecutionResult(data: Some(data), errors: [], deferred: [])
 }
 
 fn error_result(error: ExecutionError) -> ExecutionResult {
-  ExecutionResult(data: None, errors: [error])
+  ExecutionResult(data: None, errors: [error], deferred: [])
 }
 
 fn validation_error(msg: String, path: List(String)) -> ExecutionResult {
@@ -259,7 +272,7 @@ fn execute_operation(
 
   // Coerce and validate variable values against their declared types
   let exec_result = case coerce_variable_values(context, var_defs) {
-    Error(errors) -> ExecutionResult(data: None, errors: errors)
+    Error(errors) -> ExecutionResult(data: None, errors: errors, deferred: [])
     Ok(coerced_variables) -> {
       let context =
         QueryExecutionContext(..context, variable_values: coerced_variables)
@@ -568,37 +581,106 @@ fn execute_selection_set(
   object_type: schema.ObjectType,
   field_context: FieldContext,
 ) -> ExecutionResult {
-  let #(data_dict, errors_acc, has_none) =
+  let #(data_dict, errors_acc, has_none, deferred_acc) =
     list.fold(
       selection_set.selections,
-      #(dict.new(), [], False),
+      #(dict.new(), [], False, []),
       fn(acc, selection) {
-        let #(data_map, errors_list, none_found) = acc
-        let result =
-          execute_selection(context, selection, object_type, field_context)
+        let #(data_map, errors_list, none_found, deferred_list) = acc
 
-        let new_map = case result.data {
-          Some(d) ->
-            case decode.run(d, decode.dict(decode.string, decode.dynamic)) {
-              Ok(field_dict) -> dict.merge(data_map, field_dict)
-              Error(_) -> data_map
+        case get_defer_info(selection, context.variable_values) {
+          Some(#(label, True)) -> {
+            let result =
+              execute_selection(context, selection, object_type, field_context)
+            let patch =
+              DeferredPatch(
+                path: field_context.path,
+                data: result.data,
+                errors: result.errors,
+                label: label,
+              )
+            let new_deferred =
+              list.append(deferred_list, [
+                patch,
+                ..result.deferred
+              ])
+            #(data_map, errors_list, none_found, new_deferred)
+          }
+          _ -> {
+            let result =
+              execute_selection(context, selection, object_type, field_context)
+
+            let new_map = case result.data {
+              Some(d) ->
+                case decode.run(d, decode.dict(decode.string, decode.dynamic)) {
+                  Ok(field_dict) -> dict.merge(data_map, field_dict)
+                  Error(_) -> data_map
+                }
+              None -> data_map
             }
-          None -> data_map
-        }
-        let new_none = none_found || option.is_none(result.data)
+            let new_none = none_found || option.is_none(result.data)
+            let new_deferred = list.append(deferred_list, result.deferred)
 
-        #(new_map, [result.errors, ..errors_list], new_none)
+            #(new_map, [result.errors, ..errors_list], new_none, new_deferred)
+          }
+        }
       },
     )
 
   let errors = list.reverse(errors_acc) |> list.flatten
 
   case has_none, dict.is_empty(data_dict), errors {
-    True, _, _ -> ExecutionResult(data: None, errors: errors)
-    False, True, [] -> ok_result(types.to_dynamic(dict.new()))
-    False, True, _ -> ExecutionResult(data: None, errors: errors)
+    True, _, _ ->
+      ExecutionResult(data: None, errors: errors, deferred: deferred_acc)
+    False, True, [] ->
+      ExecutionResult(
+        data: Some(types.to_dynamic(dict.new())),
+        errors: [],
+        deferred: deferred_acc,
+      )
+    False, True, _ ->
+      ExecutionResult(data: None, errors: errors, deferred: deferred_acc)
     False, False, _ ->
-      ExecutionResult(data: Some(types.to_dynamic(data_dict)), errors: errors)
+      ExecutionResult(
+        data: Some(types.to_dynamic(data_dict)),
+        errors: errors,
+        deferred: deferred_acc,
+      )
+  }
+}
+
+fn get_defer_info(
+  selection: ast.Selection,
+  variables: Dict(String, Dynamic),
+) -> Option(#(Option(String), Bool)) {
+  let directives = case selection {
+    ast.InlineFragment(inline) -> inline.directives
+    ast.FragmentSpread(spread) -> spread.directives
+    ast.FieldSelection(_) -> []
+  }
+  case list.find(directives, fn(d) { d.name == "defer" }) {
+    Error(_) -> None
+    Ok(directive) -> {
+      let if_value =
+        get_directive_bool_arg(
+          [directive],
+          "defer",
+          "if",
+          variables,
+        )
+      let should_defer = option.unwrap(if_value, True)
+      let label =
+        directive.arguments
+        |> list.find(fn(a) { a.name == "label" })
+        |> result.map(fn(a) {
+          case a.value {
+            ast.StringValue(s) -> s
+            _ -> ""
+          }
+        })
+        |> option.from_result
+      Some(#(label, should_defer))
+    }
   }
 }
 
@@ -873,7 +955,7 @@ fn skip_builtin_directive(
   next: fn() -> Result(Dynamic, String),
 ) -> Result(Dynamic, String) {
   case name {
-    "skip" | "include" | "deprecated" -> Ok(value)
+    "skip" | "include" | "deprecated" | "defer" -> Ok(value)
     _ -> next()
   }
 }
@@ -1230,6 +1312,7 @@ fn handle_sub_selection_result(
       ExecutionResult(
         data: Some(make_field(response_name, types.to_dynamic(Nil))),
         errors: sub_result.errors,
+        deferred: sub_result.deferred,
       )
   }
 }
@@ -1381,6 +1464,7 @@ fn aggregate_list_results(
       ExecutionResult(
         data: Some(make_field(response_name, types.to_dynamic(data_list))),
         errors: errors,
+        deferred: [],
       )
   }
 }
@@ -1392,11 +1476,12 @@ fn handle_list_null_error(
   errors: List(ExecutionError),
 ) -> ExecutionResult {
   case is_non_null_type(field_type) {
-    True -> ExecutionResult(data: None, errors: errors)
+    True -> ExecutionResult(data: None, errors: errors, deferred: [])
     False ->
       ExecutionResult(
         data: Some(make_field(response_name, types.to_dynamic(Nil))),
         errors: errors,
+        deferred: [],
       )
   }
 }
@@ -2840,7 +2925,7 @@ pub fn execute_query_with_context(
                     location: loc,
                   )
                 })
-              ExecutionResult(data: None, errors: errors)
+              ExecutionResult(data: None, errors: errors, deferred: [])
             }
           }
         }

--- a/src/mochi/response.gleam
+++ b/src/mochi/response.gleam
@@ -89,14 +89,9 @@ pub fn partial(data: Dynamic, errors: List(GraphQLError)) -> GraphQLResponse {
 
 /// Create a response from an ExecutionResult
 pub fn from_execution_result(result: ExecutionResult) -> GraphQLResponse {
-  let errors = case result.errors {
-    [] -> None
-    errs -> Some(list.map(errs, execution_error_to_graphql_error))
-  }
-
   GraphQLResponse(
     data: result.data,
-    errors: errors,
+    errors: map_errors(result.errors),
     extensions: None,
     has_next: None,
   )
@@ -107,32 +102,24 @@ pub fn from_execution_result_incremental(
   result: ExecutionResult,
 ) -> IncrementalResponse {
   let has_deferred = !list.is_empty(result.deferred)
-  let initial_errors = case result.errors {
-    [] -> None
-    errs -> Some(list.map(errs, execution_error_to_graphql_error))
-  }
+  let last_idx = list.length(result.deferred) - 1
   let initial =
     GraphQLResponse(
       data: result.data,
-      errors: initial_errors,
+      errors: map_errors(result.errors),
       extensions: None,
       has_next: case has_deferred {
         True -> Some(True)
         False -> None
       },
     )
-  let last_idx = list.length(result.deferred) - 1
   let patches =
     result.deferred
     |> list.index_map(fn(patch, idx) {
-      let patch_errors = case patch.errors {
-        [] -> None
-        errs -> Some(list.map(errs, execution_error_to_graphql_error))
-      }
       DeferredPatchResponse(
         path: patch.path,
         data: patch.data,
-        errors: patch_errors,
+        errors: map_errors(patch.errors),
         label: patch.label,
         has_next: idx < last_idx,
       )
@@ -288,6 +275,13 @@ fn maybe_with_location(
     option.None -> err
     option.Some(#(line, col)) ->
       error.with_locations(err, [error.Location(line, col)])
+  }
+}
+
+fn map_errors(errors: List(ExecutionError)) -> Option(List(GraphQLError)) {
+  case errors {
+    [] -> None
+    errs -> Some(list.map(errs, execution_error_to_graphql_error))
   }
 }
 

--- a/src/mochi/response.gleam
+++ b/src/mochi/response.gleam
@@ -18,6 +18,23 @@ import mochi/executor.{type ExecutionError, type ExecutionResult}
 import mochi/json
 import mochi/types
 
+pub type IncrementalResponse {
+  IncrementalResponse(
+    initial: GraphQLResponse,
+    patches: List(DeferredPatchResponse),
+  )
+}
+
+pub type DeferredPatchResponse {
+  DeferredPatchResponse(
+    path: List(String),
+    data: Option(Dynamic),
+    errors: Option(List(GraphQLError)),
+    label: Option(String),
+    has_next: Bool,
+  )
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -61,6 +78,81 @@ pub fn from_execution_result(result: ExecutionResult) -> GraphQLResponse {
   }
 
   GraphQLResponse(data: result.data, errors: errors, extensions: None)
+}
+
+/// Build an incremental response from an ExecutionResult that contains deferred patches
+pub fn from_execution_result_incremental(
+  result: ExecutionResult,
+) -> IncrementalResponse {
+  let has_deferred = !list.is_empty(result.deferred)
+  let initial_errors = case result.errors {
+    [] -> None
+    errs -> Some(list.map(errs, execution_error_to_graphql_error))
+  }
+  let initial =
+    GraphQLResponse(
+      data: result.data,
+      errors: initial_errors,
+      extensions: case has_deferred {
+        True ->
+          Some(dict.from_list([#("hasNext", types.to_dynamic(True))]))
+        False -> None
+      },
+    )
+  let last_idx = list.length(result.deferred) - 1
+  let patches =
+    result.deferred
+    |> list.index_map(fn(patch, idx) {
+      let patch_errors = case patch.errors {
+        [] -> None
+        errs -> Some(list.map(errs, execution_error_to_graphql_error))
+      }
+      DeferredPatchResponse(
+        path: patch.path,
+        data: patch.data,
+        errors: patch_errors,
+        label: patch.label,
+        has_next: idx < last_idx,
+      )
+    })
+  IncrementalResponse(initial: initial, patches: patches)
+}
+
+/// Serialize an incremental response patch to Dynamic
+pub fn deferred_patch_to_dynamic(patch: DeferredPatchResponse) -> Dynamic {
+  let parts = [
+    #("path", types.to_dynamic(patch.path)),
+    #("data", case patch.data {
+      Some(d) -> d
+      None -> types.to_dynamic(Nil)
+    }),
+  ]
+  let parts = case patch.errors {
+    Some(errors) -> [#("errors", error.errors_to_dynamic(errors)), ..parts]
+    None -> parts
+  }
+  let parts = case patch.label {
+    Some(label) -> [#("label", types.to_dynamic(label)), ..parts]
+    None -> parts
+  }
+  types.to_dynamic(dict.from_list(parts))
+}
+
+/// Serialize an incremental delivery envelope to Dynamic
+/// Shape: {"incremental": [...patches], "hasNext": bool}
+pub fn incremental_envelope_to_dynamic(
+  patches: List(DeferredPatchResponse),
+  has_next: Bool,
+) -> Dynamic {
+  types.to_dynamic(
+    dict.from_list([
+      #(
+        "incremental",
+        types.to_dynamic(list.map(patches, deferred_patch_to_dynamic)),
+      ),
+      #("hasNext", types.to_dynamic(has_next)),
+    ]),
+  )
 }
 
 /// Add extensions to a response

--- a/src/mochi/response.gleam
+++ b/src/mochi/response.gleam
@@ -48,6 +48,8 @@ pub type GraphQLResponse {
     errors: Option(List(GraphQLError)),
     /// Additional metadata from extensions
     extensions: Option(Dict(String, Dynamic)),
+    /// For incremental delivery: top-level hasNext flag
+    has_next: Option(Bool),
   )
 }
 
@@ -57,17 +59,32 @@ pub type GraphQLResponse {
 
 /// Create a successful response with data
 pub fn success(data: Dynamic) -> GraphQLResponse {
-  GraphQLResponse(data: Some(data), errors: None, extensions: None)
+  GraphQLResponse(
+    data: Some(data),
+    errors: None,
+    extensions: None,
+    has_next: None,
+  )
 }
 
 /// Create an error-only response
 pub fn failure(errors: List(GraphQLError)) -> GraphQLResponse {
-  GraphQLResponse(data: None, errors: Some(errors), extensions: None)
+  GraphQLResponse(
+    data: None,
+    errors: Some(errors),
+    extensions: None,
+    has_next: None,
+  )
 }
 
 /// Create a partial response with data and errors
 pub fn partial(data: Dynamic, errors: List(GraphQLError)) -> GraphQLResponse {
-  GraphQLResponse(data: Some(data), errors: Some(errors), extensions: None)
+  GraphQLResponse(
+    data: Some(data),
+    errors: Some(errors),
+    extensions: None,
+    has_next: None,
+  )
 }
 
 /// Create a response from an ExecutionResult
@@ -77,7 +94,12 @@ pub fn from_execution_result(result: ExecutionResult) -> GraphQLResponse {
     errs -> Some(list.map(errs, execution_error_to_graphql_error))
   }
 
-  GraphQLResponse(data: result.data, errors: errors, extensions: None)
+  GraphQLResponse(
+    data: result.data,
+    errors: errors,
+    extensions: None,
+    has_next: None,
+  )
 }
 
 /// Build an incremental response from an ExecutionResult that contains deferred patches
@@ -93,8 +115,9 @@ pub fn from_execution_result_incremental(
     GraphQLResponse(
       data: result.data,
       errors: initial_errors,
-      extensions: case has_deferred {
-        True -> Some(dict.from_list([#("hasNext", types.to_dynamic(True))]))
+      extensions: None,
+      has_next: case has_deferred {
+        True -> Some(True)
         False -> None
       },
     )
@@ -219,6 +242,12 @@ pub fn to_dynamic(response: GraphQLResponse) -> Dynamic {
   // Only include extensions if present
   let parts = case response.extensions {
     Some(ext) -> [#("extensions", types.to_dynamic(ext)), ..parts]
+    None -> parts
+  }
+
+  // hasNext is top-level per incremental delivery spec (not inside extensions)
+  let parts = case response.has_next {
+    Some(v) -> [#("hasNext", types.to_dynamic(v)), ..parts]
     None -> parts
   }
 

--- a/src/mochi/response.gleam
+++ b/src/mochi/response.gleam
@@ -94,8 +94,7 @@ pub fn from_execution_result_incremental(
       data: result.data,
       errors: initial_errors,
       extensions: case has_deferred {
-        True ->
-          Some(dict.from_list([#("hasNext", types.to_dynamic(True))]))
+        True -> Some(dict.from_list([#("hasNext", types.to_dynamic(True))]))
         False -> None
       },
     )

--- a/src/mochi/validation.gleam
+++ b/src/mochi/validation.gleam
@@ -417,17 +417,14 @@ fn validate_field(ctx: ValidationContext, field: ast.Field) -> ValidationContext
       ValidationContext(..ctx, current_location: Some(#(line, column)))
     None -> ctx
   }
-  // Validate directives on field
-  let ctx = validate_directives(ctx, field.directives, "FIELD")
-
   use ctx <- skip_introspection_field(field.name, ctx, field.arguments)
   use obj_type <- require_current_type(ctx)
   use field_def <- require_field_def(ctx, obj_type, field.name)
 
   ctx
+  |> validate_directives(field.directives, "FIELD")
   |> validate_field_arguments(field, field_def)
   |> track_argument_variables(field.arguments)
-  |> validate_directives(field.directives, "FIELD")
   |> validate_field_selection_set(field, field_def)
 }
 
@@ -810,28 +807,21 @@ fn validate_directives(
   directives: List(ast.Directive),
   location: String,
 ) -> ValidationContext {
-  // Check for unknown directives and duplicate non-repeatable directives
-  let #(seen, ctx) =
-    list.fold(directives, #(set.new(), ctx), fn(acc, directive) {
-      let #(seen_set, ctx) = acc
-      let ctx = validate_single_directive(ctx, directive, location)
-
-      // Check for duplicate non-repeatable directives
-      case set.contains(seen_set, directive.name) {
-        True ->
-          case is_repeatable_directive(ctx.schema, directive.name) {
-            True -> #(seen_set, ctx)
-            False -> #(
-              seen_set,
-              add_error(ctx, DuplicateDirective(directive.name)),
-            )
-          }
-        False -> #(set.insert(seen_set, directive.name), ctx)
-      }
-    })
-
-  let _ = seen
-  ctx
+  list.fold(directives, #(set.new(), ctx), fn(acc, directive) {
+    let #(seen_set, ctx) = acc
+    let ctx = validate_single_directive(ctx, directive, location)
+    case set.contains(seen_set, directive.name) {
+      True ->
+        case is_repeatable_directive(ctx.schema, directive.name) {
+          True -> #(seen_set, ctx)
+          False -> #(
+            seen_set,
+            add_error(ctx, DuplicateDirective(directive.name)),
+          )
+        }
+      False -> #(set.insert(seen_set, directive.name), ctx)
+    }
+  }).1
 }
 
 /// Validate a single directive

--- a/src/mochi/validation.gleam
+++ b/src/mochi/validation.gleam
@@ -851,9 +851,14 @@ fn validate_single_directive(
         _ -> add_error(ctx, DirectiveNotAllowed(directive.name, location))
       }
     "specifiedBy" ->
-      // Valid only on SCALAR
       case location {
         "SCALAR" -> ctx
+        _ -> add_error(ctx, DirectiveNotAllowed(directive.name, location))
+      }
+    "defer" ->
+      case location {
+        "FRAGMENT_SPREAD" | "INLINE_FRAGMENT" ->
+          validate_defer_args(ctx, directive)
         _ -> add_error(ctx, DirectiveNotAllowed(directive.name, location))
       }
     _ ->
@@ -894,13 +899,26 @@ fn validate_directive_location(
 /// Check if a directive is repeatable
 fn is_repeatable_directive(schema: Schema, directive_name: String) -> Bool {
   case directive_name {
-    "skip" | "include" | "deprecated" | "specifiedBy" -> False
+    "skip" | "include" | "deprecated" | "specifiedBy" | "defer" -> False
     _ ->
       case dict.get(schema.directives, directive_name) {
         Ok(directive_def) -> directive_def.is_repeatable
         Error(_) -> False
       }
   }
+}
+
+fn validate_defer_args(
+  ctx: ValidationContext,
+  directive: ast.Directive,
+) -> ValidationContext {
+  list.fold(directive.arguments, ctx, fn(ctx, arg) {
+    case arg.name {
+      "if" -> track_value_variables(ctx, arg.value)
+      "label" -> ctx
+      _ -> add_error(ctx, UnknownArgument("@defer", arg.name))
+    }
+  })
 }
 
 fn validate_skip_include_args(

--- a/src/mochi/validation.gleam
+++ b/src/mochi/validation.gleam
@@ -77,6 +77,13 @@ pub type ValidationError {
   SelectionSetNotAllowed(field_name: String, type_name: String)
   /// Fields with same response name cannot be merged
   FieldsCannotMerge(field_name: String, reason: String)
+  /// Argument value has the wrong type
+  ArgumentTypeMismatch(
+    field_name: String,
+    argument_name: String,
+    expected_type: String,
+    got: String,
+  )
 }
 
 pub type LocatedError =
@@ -914,8 +921,26 @@ fn validate_defer_args(
 ) -> ValidationContext {
   list.fold(directive.arguments, ctx, fn(ctx, arg) {
     case arg.name {
-      "if" -> track_value_variables(ctx, arg.value)
-      "label" -> ctx
+      "if" ->
+        case arg.value {
+          ast.BooleanValue(_) | ast.VariableValue(_) ->
+            track_value_variables(ctx, arg.value)
+          _ ->
+            add_error(
+              ctx,
+              ArgumentTypeMismatch("@defer", "if", "Boolean", "non-boolean"),
+            )
+        }
+      "label" ->
+        case arg.value {
+          ast.StringValue(_) | ast.VariableValue(_) ->
+            track_value_variables(ctx, arg.value)
+          _ ->
+            add_error(
+              ctx,
+              ArgumentTypeMismatch("@defer", "label", "String", "non-string"),
+            )
+        }
       _ -> add_error(ctx, UnknownArgument("@defer", arg.name))
     }
   })
@@ -1070,6 +1095,15 @@ pub fn format_error(error: ValidationError) -> String {
       <> "\" conflict because "
       <> reason
       <> ". Use different aliases on the fields to fetch both if this was intentional."
+    ArgumentTypeMismatch(field_name, arg_name, expected, got) ->
+      "Argument \""
+      <> arg_name
+      <> "\" on \""
+      <> field_name
+      <> "\" has invalid type: expected "
+      <> expected
+      <> ", got "
+      <> got
   }
 }
 

--- a/test/defer_test.gleam
+++ b/test/defer_test.gleam
@@ -1,12 +1,16 @@
+import gleam/dict
 import gleam/dynamic/decode
 import gleam/list
-import gleam/option.{Some}
+import gleam/option.{None, Some}
+import gleam/result
+import gleam/string
 import gleeunit/should
 import mochi/executor
 import mochi/query
 import mochi/response
 import mochi/schema
 import mochi/types
+import mochi/validation
 
 pub type User {
   User(id: String, name: String, bio: String)
@@ -157,4 +161,145 @@ pub fn defer_multiple_patches_test() {
   let assert [first_patch, last_patch] = incremental.patches
   should.equal(first_patch.has_next, True)
   should.equal(last_patch.has_next, False)
+}
+
+// ============================================================================
+// hasNext placement tests
+// ============================================================================
+
+pub fn has_next_at_top_level_in_json_test() {
+  let schema_def = build_test_schema()
+  let result =
+    executor.execute_query(schema_def, "{ user { id ... @defer { bio } } }")
+  let incremental = response.from_execution_result_incremental(result)
+  let json = response.to_json(incremental.initial)
+
+  should.be_true(string.contains(json, "\"hasNext\":true"))
+  should.be_false(string.contains(json, "\"extensions\""))
+}
+
+pub fn no_has_next_when_no_deferred_test() {
+  let schema_def = build_test_schema()
+  let result = executor.execute_query(schema_def, "{ user { id name bio } }")
+  let json = response.to_json(response.from_execution_result(result))
+
+  should.be_false(string.contains(json, "hasNext"))
+}
+
+// ============================================================================
+// Validation: @defer arg type checking
+// ============================================================================
+
+pub fn defer_if_non_boolean_fails_validation_test() {
+  let schema_def = build_test_schema()
+  let q = "{ user { id ... @defer(if: 42) { bio } } }"
+  let result = validation.validate_query(q, schema_def)
+  let errors = result |> result.unwrap_error([])
+  should.be_true(
+    list.any(errors, fn(e) {
+      string.contains(validation.format_error(e), "invalid type")
+    }),
+  )
+}
+
+pub fn defer_label_non_string_fails_validation_test() {
+  let schema_def = build_test_schema()
+  let q = "{ user { id ... @defer(label: 99) { bio } } }"
+  let result = validation.validate_query(q, schema_def)
+  let errors = result |> result.unwrap_error([])
+  should.be_true(
+    list.any(errors, fn(e) {
+      string.contains(validation.format_error(e), "invalid type")
+    }),
+  )
+}
+
+pub fn defer_valid_boolean_string_args_passes_validation_test() {
+  let schema_def = build_test_schema()
+  let q = "{ user { id ... @defer(if: true, label: \"x\") { bio } } }"
+  let result = executor.execute_query(schema_def, q)
+  should.equal(result.errors, [])
+}
+
+// ============================================================================
+// @defer on fragment spread
+// ============================================================================
+
+pub fn defer_on_fragment_spread_test() {
+  let schema_def = build_test_schema()
+  let q =
+    "fragment Bio on User { bio }
+     { user { id ...Bio @defer } }"
+  let result = executor.execute_query(schema_def, q)
+
+  should.equal(result.errors, [])
+  should.equal(list.length(result.deferred), 1)
+}
+
+// ============================================================================
+// @defer in list — deferred patches propagate from list items
+// ============================================================================
+
+pub fn defer_in_list_propagates_patches_test() {
+  let user_type =
+    types.object("User")
+    |> types.id("id", fn(u: User) { u.id })
+    |> types.string("name", fn(u: User) { u.name })
+    |> types.string("bio", fn(u: User) { u.bio })
+    |> types.build(decode_user)
+
+  let users_query =
+    query.query(
+      "users",
+      schema.List(schema.Named("User")),
+      fn(_info) {
+        Ok(
+          types.to_dynamic([
+            User("1", "Alice", "Dev"),
+            User("2", "Bob", "Ops"),
+          ]),
+        )
+      },
+      fn(u) { types.to_dynamic(u) },
+    )
+
+  let schema_def =
+    query.new()
+    |> query.add_query(users_query)
+    |> query.add_type(user_type)
+    |> query.build
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ users { id ... @defer { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.be_true(result.deferred != [])
+}
+
+// ============================================================================
+// Variable label
+// ============================================================================
+
+pub fn defer_label_from_variable_test() {
+  let schema_def = build_test_schema()
+  let q = "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
+  let vars = dict.from_list([#("lbl", types.to_dynamic("my-label"))])
+  let result = executor.execute_query_with_variables(schema_def, q, vars)
+
+  should.equal(result.errors, [])
+  let assert [patch] = result.deferred
+  should.equal(patch.label, Some("my-label"))
+}
+
+pub fn defer_label_missing_variable_gives_no_label_test() {
+  let schema_def = build_test_schema()
+  let q = "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
+  let result = executor.execute_query_with_variables(schema_def, q, dict.new())
+
+  should.equal(result.errors, [])
+  let assert [patch] = result.deferred
+  should.equal(patch.label, None)
 }

--- a/test/defer_test.gleam
+++ b/test/defer_test.gleam
@@ -270,10 +270,7 @@ pub fn defer_in_list_propagates_patches_test() {
     |> query.build
 
   let result =
-    executor.execute_query(
-      schema_def,
-      "{ users { id ... @defer { bio } } }",
-    )
+    executor.execute_query(schema_def, "{ users { id ... @defer { bio } } }")
 
   should.equal(result.errors, [])
   should.be_true(result.deferred != [])
@@ -285,7 +282,8 @@ pub fn defer_in_list_propagates_patches_test() {
 
 pub fn defer_label_from_variable_test() {
   let schema_def = build_test_schema()
-  let q = "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
+  let q =
+    "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
   let vars = dict.from_list([#("lbl", types.to_dynamic("my-label"))])
   let result = executor.execute_query_with_variables(schema_def, q, vars)
 
@@ -296,7 +294,8 @@ pub fn defer_label_from_variable_test() {
 
 pub fn defer_label_missing_variable_gives_no_label_test() {
   let schema_def = build_test_schema()
-  let q = "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
+  let q =
+    "query Q($lbl: String) { user { id ... @defer(label: $lbl) { bio } } }"
   let result = executor.execute_query_with_variables(schema_def, q, dict.new())
 
   should.equal(result.errors, [])

--- a/test/defer_test.gleam
+++ b/test/defer_test.gleam
@@ -42,10 +42,7 @@ pub fn defer_inline_fragment_test() {
   let schema_def = build_test_schema()
 
   let result =
-    executor.execute_query(
-      schema_def,
-      "{ user { id ... @defer { bio } } }",
-    )
+    executor.execute_query(schema_def, "{ user { id ... @defer { bio } } }")
 
   should.equal(result.errors, [])
   should.be_true(option.is_some(result.data))
@@ -114,18 +111,10 @@ pub fn defer_non_deferred_in_initial_test() {
   should.be_true(option.is_some(result.data))
 
   let assert Some(data) = result.data
-  let name_result =
-    decode.run(
-      data,
-      decode.at(["user", "name"], decode.string),
-    )
+  let name_result = decode.run(data, decode.at(["user", "name"], decode.string))
   should.be_ok(name_result)
 
-  let id_result =
-    decode.run(
-      data,
-      decode.at(["user", "id"], decode.string),
-    )
+  let id_result = decode.run(data, decode.at(["user", "id"], decode.string))
   should.be_ok(id_result)
 
   should.equal(list.length(result.deferred), 1)

--- a/test/defer_test.gleam
+++ b/test/defer_test.gleam
@@ -1,0 +1,171 @@
+import gleam/dynamic/decode
+import gleam/list
+import gleam/option.{Some}
+import gleeunit/should
+import mochi/executor
+import mochi/query
+import mochi/response
+import mochi/schema
+import mochi/types
+
+pub type User {
+  User(id: String, name: String, bio: String)
+}
+
+fn decode_user(_dyn) {
+  Ok(User("1", "Alice", "A developer"))
+}
+
+fn build_test_schema() -> schema.Schema {
+  let user_type =
+    types.object("User")
+    |> types.id("id", fn(u: User) { u.id })
+    |> types.string("name", fn(u: User) { u.name })
+    |> types.string("bio", fn(u: User) { u.bio })
+    |> types.build(decode_user)
+
+  let user_query =
+    query.query(
+      "user",
+      schema.Named("User"),
+      fn(_info) { Ok(types.to_dynamic(User("1", "Alice", "A developer"))) },
+      fn(u) { types.to_dynamic(u) },
+    )
+
+  query.new()
+  |> query.add_query(user_query)
+  |> query.add_type(user_type)
+  |> query.build
+}
+
+pub fn defer_inline_fragment_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.be_true(option.is_some(result.data))
+
+  let patches = result.deferred
+  should.equal(list.length(patches), 1)
+
+  let assert [patch] = patches
+  should.be_true(option.is_some(patch.data))
+  should.equal(patch.errors, [])
+}
+
+pub fn defer_if_false_no_patch_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer(if: false) { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.be_true(option.is_some(result.data))
+  should.equal(result.deferred, [])
+}
+
+pub fn defer_if_true_produces_patch_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer(if: true) { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.equal(list.length(result.deferred), 1)
+}
+
+pub fn defer_with_label_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer(label: \"bio-patch\") { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.equal(list.length(result.deferred), 1)
+
+  let assert [patch] = result.deferred
+  should.equal(patch.label, Some("bio-patch"))
+}
+
+pub fn defer_non_deferred_in_initial_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id name ... @defer { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.be_true(option.is_some(result.data))
+
+  let assert Some(data) = result.data
+  let name_result =
+    decode.run(
+      data,
+      decode.at(["user", "name"], decode.string),
+    )
+  should.be_ok(name_result)
+
+  let id_result =
+    decode.run(
+      data,
+      decode.at(["user", "id"], decode.string),
+    )
+  should.be_ok(id_result)
+
+  should.equal(list.length(result.deferred), 1)
+}
+
+pub fn defer_incremental_response_format_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer(label: \"details\") { bio } } }",
+    )
+
+  let incremental = response.from_execution_result_incremental(result)
+
+  should.equal(list.length(incremental.patches), 1)
+  should.be_true(response.has_data(incremental.initial))
+
+  let assert [patch] = incremental.patches
+  should.equal(patch.label, Some("details"))
+  should.equal(patch.has_next, False)
+}
+
+pub fn defer_multiple_patches_test() {
+  let schema_def = build_test_schema()
+
+  let result =
+    executor.execute_query(
+      schema_def,
+      "{ user { id ... @defer(label: \"first\") { name } ... @defer(label: \"second\") { bio } } }",
+    )
+
+  should.equal(result.errors, [])
+  should.equal(list.length(result.deferred), 2)
+
+  let incremental = response.from_execution_result_incremental(result)
+  should.equal(list.length(incremental.patches), 2)
+
+  let assert [first_patch, last_patch] = incremental.patches
+  should.equal(first_patch.has_next, True)
+  should.equal(last_patch.has_next, False)
+}

--- a/test/response_test.gleam
+++ b/test/response_test.gleam
@@ -81,7 +81,8 @@ pub fn partial_response_test() {
 pub fn from_execution_result_success_test() {
   let data =
     types.to_dynamic(dict.from_list([#("result", types.to_dynamic("ok"))]))
-  let exec_result = executor.ExecutionResult(data: Some(data), errors: [], deferred: [])
+  let exec_result =
+    executor.ExecutionResult(data: Some(data), errors: [], deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 
@@ -102,7 +103,8 @@ pub fn from_execution_result_with_errors_test() {
     ),
     executor.ResolverError("Database error", ["query", "users"], location: None),
   ]
-  let exec_result = executor.ExecutionResult(data: Some(data), errors: errors, deferred: [])
+  let exec_result =
+    executor.ExecutionResult(data: Some(data), errors: errors, deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 
@@ -119,7 +121,8 @@ pub fn from_execution_result_with_errors_test() {
 
 pub fn from_execution_result_failure_test() {
   let errors = [executor.TypeError("Type mismatch", ["field"], location: None)]
-  let exec_result = executor.ExecutionResult(data: None, errors: errors, deferred: [])
+  let exec_result =
+    executor.ExecutionResult(data: None, errors: errors, deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 

--- a/test/response_test.gleam
+++ b/test/response_test.gleam
@@ -81,7 +81,7 @@ pub fn partial_response_test() {
 pub fn from_execution_result_success_test() {
   let data =
     types.to_dynamic(dict.from_list([#("result", types.to_dynamic("ok"))]))
-  let exec_result = executor.ExecutionResult(data: Some(data), errors: [])
+  let exec_result = executor.ExecutionResult(data: Some(data), errors: [], deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 
@@ -102,7 +102,7 @@ pub fn from_execution_result_with_errors_test() {
     ),
     executor.ResolverError("Database error", ["query", "users"], location: None),
   ]
-  let exec_result = executor.ExecutionResult(data: Some(data), errors: errors)
+  let exec_result = executor.ExecutionResult(data: Some(data), errors: errors, deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 
@@ -119,7 +119,7 @@ pub fn from_execution_result_with_errors_test() {
 
 pub fn from_execution_result_failure_test() {
   let errors = [executor.TypeError("Type mismatch", ["field"], location: None)]
-  let exec_result = executor.ExecutionResult(data: None, errors: errors)
+  let exec_result = executor.ExecutionResult(data: None, errors: errors, deferred: [])
 
   let resp = response.from_execution_result(exec_result)
 


### PR DESCRIPTION
## Summary

- Implements the GraphQL `@defer` directive (RFC stage 2)
- `@defer` on inline fragments and fragment spreads moves that selection's result into a `DeferredPatch` instead of the initial response data
- `if: Boolean` argument (default `true`) — `@defer(if: false)` executes inline as normal
- `label: String` argument propagates to each patch for client-side tracking
- Validation: only valid at `FRAGMENT_SPREAD` and `INLINE_FRAGMENT` locations
- `response.gleam`: new `from_execution_result_incremental` builds an initial response (`hasNext: true`) plus incremental patches in the `{"incremental": [...], "hasNext": bool}` wire format
- Execution is synchronous — deferred fragments run in the same pass, results just land in `deferred` instead of `data`. Async streaming is a transport concern (mochi_sse/ws layer)

## Test plan

- [ ] All 827 tests pass
- [ ] `@defer` on inline fragment: non-deferred fields in initial response, deferred fields in patches
- [ ] `@defer(if: false)` executes inline (no patch)
- [ ] `@defer(if: true)` defers
- [ ] `label` propagates to `DeferredPatch`
- [ ] Incremental response format matches spec wire format
- [ ] Multiple patches have correct `hasNext` ordering